### PR TITLE
Fix message maker and add take offer button

### DIFF
--- a/api/chat/self.ts
+++ b/api/chat/self.ts
@@ -14,7 +14,9 @@ export default async function handler(req: any, res: any) {
 
   try {
     const body =
-      typeof req.body === "string" ? JSON.parse(req.body || "{}") : req.body || {};
+      typeof req.body === "string"
+        ? JSON.parse(req.body || "{}")
+        : req.body || {};
     const address = String(body?.address || req.query?.address || "").trim();
     if (!address) return res.status(400).json({ error: "address_required" });
 

--- a/api/chat/self.ts
+++ b/api/chat/self.ts
@@ -1,0 +1,46 @@
+import { prisma } from "../_prisma";
+
+function allow(res: any) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST,OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+}
+
+export default async function handler(req: any, res: any) {
+  allow(res);
+  if (req.method === "OPTIONS") return res.status(204).end();
+  if (req.method !== "POST")
+    return res.status(405).json({ error: "method_not_allowed" });
+
+  try {
+    const body =
+      typeof req.body === "string" ? JSON.parse(req.body || "{}") : req.body || {};
+    const address = String(body?.address || req.query?.address || "").trim();
+    if (!address) return res.status(400).json({ error: "address_required" });
+
+    let order = await prisma.order.findFirst({
+      where: { makerAddress: address, takerAddress: address },
+      orderBy: { createdAt: "desc" },
+    });
+
+    if (!order) {
+      order = await prisma.order.create({
+        data: {
+          title: "Favorites",
+          makerAddress: address,
+          takerAddress: address,
+          priceTON: 0,
+          nPercent: 0,
+          makerDeposit: 0,
+          takerStake: 0,
+          status: "created",
+        },
+      });
+    }
+
+    return res.status(200).json({ ok: true, order });
+  } catch (e) {
+    console.error("ensureSelfChat error:", e);
+    return res.status(500).json({ error: "internal_error" });
+  }
+}

--- a/client/pages/Offer.tsx
+++ b/client/pages/Offer.tsx
@@ -154,7 +154,10 @@ export default function OfferPage() {
                     const rp = await fetch(`/api/orders/${orderId}`, {
                       method: "PATCH",
                       headers: { "Content-Type": "application/json" },
-                      body: JSON.stringify({ action: "take", takerAddress: me }),
+                      body: JSON.stringify({
+                        action: "take",
+                        takerAddress: me,
+                      }),
                     });
                     const jp = await rp.json();
                     if (!rp.ok) throw new Error(jp?.error || "failed");

--- a/client/pages/Offer.tsx
+++ b/client/pages/Offer.tsx
@@ -127,6 +127,46 @@ export default function OfferPage() {
               >
                 Message Maker
               </Button>
+              <Button
+                variant="secondary"
+                onClick={async () => {
+                  try {
+                    if (!me) {
+                      alert("Connect wallet to take the offer");
+                      return;
+                    }
+                    const maker = String(offer?.makerAddress || "");
+                    const r = await fetch("/api/orders", {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({
+                        title: String(offer?.title || "Order"),
+                        makerAddress: maker,
+                        priceTON: Number(offer?.budgetTON || 0),
+                        offerId: String(offer?.id || id || ""),
+                      }),
+                    });
+                    const j = await r.json();
+                    if (!r.ok) throw new Error(j?.error || "failed");
+                    const orderId = String(j.id || j.order?.id || "");
+                    if (!orderId) throw new Error("no_order");
+
+                    const rp = await fetch(`/api/orders/${orderId}`, {
+                      method: "PATCH",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({ action: "take", takerAddress: me }),
+                    });
+                    const jp = await rp.json();
+                    if (!rp.ok) throw new Error(jp?.error || "failed");
+
+                    navigate(`/chat/${orderId}`);
+                  } catch (_e) {
+                    alert("Unable to take offer");
+                  }
+                }}
+              >
+                Take Offer
+              </Button>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Purpose

The user reported that the message maker function was not working and throwing an "unable to start chat" error when deployed on Vercel. They also requested adding a "Take Offer" button next to the existing "Message Maker" button to improve the user experience.

## Code changes

- **Added new API endpoint** (`api/chat/self.ts`): Creates a self-chat functionality that ensures users can start chats by creating or finding orders where the maker and taker addresses are the same
- **Enhanced Offer page** (`client/pages/Offer.tsx`): Added a "Take Offer" button that allows users to take an offer by creating an order and automatically navigating to the chat interface
- **Improved error handling**: Both new features include proper error handling and user feedback for failed operationsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/538672015e8f4b0c8d117124be6ad534/aura-haven)

👀 [Preview Link](https://538672015e8f4b0c8d117124be6ad534-aura-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>538672015e8f4b0c8d117124be6ad534</projectId>-->
<!--<branchName>aura-haven</branchName>-->