### PR TITLE
Add chat navigation buttons for orders and favorites

### DIFF
--- a/client/pages/Chat.tsx
+++ b/client/pages/Chat.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo } from "react";
 import { useWalletAddress } from "@/hooks/useTon";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
 
 interface Order {
   id: string;
@@ -15,6 +16,7 @@ export default function Chat() {
   const addr = useWalletAddress();
   const [items, setItems] = useState<Order[]>([]);
   const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!addr) return;
@@ -22,7 +24,6 @@ export default function Chat() {
     async function run() {
       try {
         setLoading(true);
-        // Ensure a self-chat (Favorites) exists
         await fetch(`/api/chat/self`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -64,6 +65,31 @@ export default function Chat() {
     return { inProgress, completed };
   }, [items]);
 
+  function getPeerForOrder(o: Order, me?: string | null) {
+    const maker = o.makerAddress;
+    const taker = o.takerAddress || "";
+    if (!me) return maker || taker;
+    return me === maker ? taker : maker;
+  }
+
+  async function openSelfChat() {
+    if (!addr) return;
+    const r = await fetch(`/api/chat/self`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ address: addr }),
+    });
+    const j = await r.json().catch(() => ({}));
+    const id = String(j?.order?.id || "");
+    if (id) navigate(`/chat/${id}?peer=${encodeURIComponent(addr)}`);
+  }
+
+  function openChat(o: Order) {
+    const peer = getPeerForOrder(o, addr);
+    const url = `/chat/${o.id}${peer ? `?peer=${encodeURIComponent(peer)}` : ""}`;
+    navigate(url);
+  }
+
   return (
     <div className="min-h-screen bg-[hsl(217,33%,9%)] text-white">
       <div className="mx-auto w-full max-w-2xl px-4 py-10">
@@ -82,22 +108,19 @@ export default function Chat() {
               In Progress
             </h2>
             <div className="mt-2 space-y-2">
-              {/* Favorites self chat shortcut */}
               {addr && (
-                <Link
-                  to={(() => {
-                    const self = items.find(
-                      (i) => i.makerAddress === addr && i.takerAddress === addr,
-                    );
-                    return `/chat/${self ? self.id : ""}`;
-                  })()}
-                  className="block rounded-lg border border-white/10 bg-white/10 p-3 hover:bg-white/20"
-                >
-                  <div className="font-medium truncate">Favorites</div>
-                  <div className="text-xs text-white/60 mt-1">
-                    Private notes
+                <div className="flex items-center justify-between rounded-lg border border-white/10 bg-white/10 p-3">
+                  <div>
+                    <div className="font-medium truncate">Favorites</div>
+                    <div className="text-xs text-white/60 mt-1">Private notes</div>
                   </div>
-                </Link>
+                  <Button
+                    onClick={openSelfChat}
+                    className="bg-primary text-primary-foreground"
+                  >
+                    Favorites
+                  </Button>
+                </div>
               )}
 
               {sections.inProgress.length === 0 && (
@@ -106,16 +129,26 @@ export default function Chat() {
                 </div>
               )}
               {sections.inProgress.map((o) => (
-                <Link
+                <div
                   key={o.id}
-                  to={`/chat/${o.id}`}
-                  className="block rounded-lg border border-white/10 bg-white/5 p-3 hover:bg-white/10"
+                  className="rounded-lg border border-white/10 bg-white/5 p-3 hover:bg-white/10"
                 >
-                  <div className="font-medium truncate">{o.title}</div>
-                  <div className="text-xs text-white/60 mt-1">
-                    {o.status} • {new Date(o.createdAt).toLocaleString()}
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="font-medium truncate">{o.title}</div>
+                      <div className="text-xs text-white/60 mt-1">
+                        {o.status} • {new Date(o.createdAt).toLocaleString()}
+                      </div>
+                    </div>
+                    <Button
+                      size="sm"
+                      onClick={() => openChat(o)}
+                      className="bg-primary text-primary-foreground"
+                    >
+                      Chat
+                    </Button>
                   </div>
-                </Link>
+                </div>
               ))}
             </div>
 
@@ -129,16 +162,26 @@ export default function Chat() {
                 </div>
               )}
               {sections.completed.map((o) => (
-                <Link
+                <div
                   key={o.id}
-                  to={`/chat/${o.id}`}
-                  className="block rounded-lg border border-white/10 bg-white/5 p-3 hover:bg-white/10"
+                  className="rounded-lg border border-white/10 bg-white/5 p-3 hover:bg-white/10"
                 >
-                  <div className="font-medium truncate">{o.title}</div>
-                  <div className="text-xs text-white/60 mt-1">
-                    completed • {new Date(o.createdAt).toLocaleString()}
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="font-medium truncate">{o.title}</div>
+                      <div className="text-xs text-white/60 mt-1">
+                        completed • {new Date(o.createdAt).toLocaleString()}
+                      </div>
+                    </div>
+                    <Button
+                      size="sm"
+                      onClick={() => openChat(o)}
+                      className="bg-primary text-primary-foreground"
+                    >
+                      Chat
+                    </Button>
                   </div>
-                </Link>
+                </div>
               ))}
             </div>
           </>

--- a/client/pages/Chat.tsx
+++ b/client/pages/Chat.tsx
@@ -112,7 +112,9 @@ export default function Chat() {
                 <div className="flex items-center justify-between rounded-lg border border-white/10 bg-white/10 p-3">
                   <div>
                     <div className="font-medium truncate">Favorites</div>
-                    <div className="text-xs text-white/60 mt-1">Private notes</div>
+                    <div className="text-xs text-white/60 mt-1">
+                      Private notes
+                    </div>
                   </div>
                   <Button
                     onClick={openSelfChat}


### PR DESCRIPTION
## Purpose

The user requested to add navigation functionality to the chat section:
- Add ability to navigate to chat with another person by clicking a chat button for specific orders (using order ID and account ID)
- Add navigation to self-chat (Favorites) by clicking a favorites button
- Follow clean code principles (DRY, KISS, YAGNI) for maintainable implementation

## Code changes

- **Navigation enhancement**: Replaced `Link` components with interactive buttons using `useNavigate` hook
- **Chat button functionality**: Added `openChat()` function that determines the correct peer for each order and navigates to the chat with proper URL parameters
- **Favorites button**: Implemented `openSelfChat()` function that creates/accesses self-chat and navigates to it
- **Peer detection**: Added `getPeerForOrder()` helper function to identify the correct chat partner (maker vs taker)
- **UI improvements**: Restructured order items with flex layout to accommodate chat buttons alongside order information
- **Button integration**: Added `Button` component import and implemented consistent button styling for both favorites and order chatsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/538672015e8f4b0c8d117124be6ad534/cosmos-sanctuary)

👀 [Preview Link](https://538672015e8f4b0c8d117124be6ad534-cosmos-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>538672015e8f4b0c8d117124be6ad534</projectId>-->
<!--<branchName>cosmos-sanctuary</branchName>-->