### PR TITLE
Fix offers API budget filtering and remove unused field

### DIFF
--- a/server/routes/offers.ts
+++ b/server/routes/offers.ts
@@ -17,9 +17,6 @@ export const getOfferById: RequestHandler = async (req, res) => {
         createdAt: true,
 
         creator: { select: { address: true } },
-
-        makerAddress: true,
-
       },
     });
     if (!offerRaw) return res.status(404).json({ error: "not_found" });
@@ -43,8 +40,17 @@ export const listOffers: RequestHandler = async (req, res) => {
   try {
     const qRaw = String((req.query?.q as string) || "").trim();
     const stackRaw = String((req.query?.stack as string) || "").trim();
-    const minBudget = Number((req.query?.minBudget as string) || "");
-    const maxBudget = Number((req.query?.maxBudget as string) || "");
+    const minBudgetRaw = req.query?.minBudget as string | undefined;
+    const maxBudgetRaw = req.query?.maxBudget as string | undefined;
+
+    const minBudget =
+      minBudgetRaw !== undefined && minBudgetRaw !== ""
+        ? Number(minBudgetRaw)
+        : undefined;
+    const maxBudget =
+      maxBudgetRaw !== undefined && maxBudgetRaw !== ""
+        ? Number(maxBudgetRaw)
+        : undefined;
 
     const tokens = [
       ...(qRaw ? qRaw.split(/\s+/).filter(Boolean) : []),
@@ -64,10 +70,10 @@ export const listOffers: RequestHandler = async (req, res) => {
       );
     }
 
-    if (!Number.isNaN(minBudget)) {
+    if (minBudget !== undefined && Number.isFinite(minBudget)) {
       filters.push({ budgetTON: { gte: minBudget } });
     }
-    if (!Number.isNaN(maxBudget)) {
+    if (maxBudget !== undefined && Number.isFinite(maxBudget)) {
       filters.push({ budgetTON: { lte: maxBudget } });
     }
 


### PR DESCRIPTION
## Purpose

User reported 500 errors when loading offers on both main and take pages, as well as issues with the favorites functionality showing wallet connection errors. This fix addresses the server-side issues that were likely causing the 500 errors when fetching offers.

## Code changes

- **Improved budget parameter handling**: Enhanced validation for `minBudget` and `maxBudget` query parameters by properly checking for undefined/empty values before conversion to numbers
- **Fixed budget filtering logic**: Replaced `Number.isNaN()` checks with proper `undefined` and `Number.isFinite()` validation to prevent invalid budget filters
- **Removed unused field**: Cleaned up `makerAddress` field from offer selection in `getOfferById` endpoint
- **Enhanced type safety**: Added explicit type annotations for budget parameters to prevent runtime errorsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/538672015e8f4b0c8d117124be6ad534/neon-world)

👀 [Preview Link](https://538672015e8f4b0c8d117124be6ad534-neon-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>538672015e8f4b0c8d117124be6ad534</projectId>-->
<!--<branchName>neon-world</branchName>-->